### PR TITLE
ci: update coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -66,6 +66,7 @@ jobs:
             --branch \
             --ignore-not-existing \
             --ignore "/*" \
+            --ignore "src/{main}.rs" \
             --excl-line "#\\[derive\\(" \
             -o ./coverage/lcov.info
 


### PR DESCRIPTION
we can ignore the `src/main.rs` while the coverage check