### PR TITLE
patch: update the afrim dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ inhibit = ["afrim/inhibit"]
 rhai = ["afrim/rhai"]
 
 [dependencies]
-afrim = { version = "0.5.4", default-features = false, path = "../afrim/service" }
+afrim = { version = "0.5.4", default-features = false, git = "https://github.com/pythonbrad/afrim", rev = "fcb7721" }
 anyhow = "1.0.82"
 clap = "4.5.4"
 rstk = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ inhibit = ["afrim/inhibit"]
 rhai = ["afrim/rhai"]
 
 [dependencies]
-afrim = { version = "0.5.4", default-features = false, git = "https://github.com/pythonbrad/afrim", rev = "7e5daba" }
+afrim = { version = "0.5.4", default-features = false, path = "../afrim/service" }
+anyhow = "1.0.82"
 clap = "4.5.4"
 rstk = "0.3.0"
 serde = { version = "1.0.197", features = ["serde_derive"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
+use anyhow::{Context, Result};
 use serde::Deserialize;
-use std::{error, fs, path::Path};
+use std::{fs, path::Path};
 use toml::{self};
 
 #[derive(Clone, Deserialize, Debug, Default)]
@@ -95,9 +96,11 @@ impl Default for Info {
 }
 
 impl Config {
-    pub fn from_file(filepath: &Path) -> Result<Self, Box<dyn error::Error>> {
-        let content = fs::read_to_string(filepath)?;
-        let config: Self = toml::from_str(&content)?;
+    pub fn from_file(filepath: &Path) -> Result<Self> {
+        let content = fs::read_to_string(filepath)
+            .with_context(|| format!("Couldn't open file {filepath:?}"))?;
+        let config: Self = toml::from_str(&content)
+            .with_context(|| format!("Failed to parse configuration file {filepath:?}"))?;
 
         Ok(config)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,6 @@ impl Frontend for Wish {
 
         loop {
             let command = self.rx.as_ref().unwrap().recv()?;
-            dbg!(&command);
             match command {
                 Command::ScreenSize(screen) => self.tooltip.update_screen(screen),
                 Command::Position(position) => self.tooltip.update_position(position),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,11 +32,11 @@ impl Wish {
             };
 
             // The default behavior is to close the window.
-            // But since this window, represent the window,
+            // But since this window, represent the main window,
             // we don't want an unexpected behavior.
             // It's better for us to manage the close.
             //
-            // Note that, this close is done via the title bar.
+            // Note that, this close button is on the title bar.
             wish.on_close(Self::kill);
 
             init_rstk_ext();
@@ -154,7 +154,7 @@ mod tests {
         let (tx1, rx1) = mpsc::channel();
         let (tx2, rx2) = mpsc::channel();
 
-        thread::spawn(move || {
+        let afrim_wish_thread = thread::spawn(move || {
             afrim_wish.init(tx2, rx1).unwrap();
             afrim_wish.listen().unwrap();
         });
@@ -247,7 +247,12 @@ mod tests {
         );
         tx1.send(Command::Update).unwrap();
 
+        // We end the communication.
         tx1.send(Command::End).unwrap();
         assert_eq!(rx2.recv().unwrap(), Command::End);
+        assert!(rx2.recv().is_err());
+
+        // We wait the afrim to end properly.
+        afrim_wish_thread.join().unwrap();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,10 +3,8 @@
 use afrim::{run, Config as ClafricaConfig};
 use afrim_wish::{Config as WishConfig, Wish};
 use clap::Parser;
-use std::process;
-use std::thread;
 
-/// Afrim CLI.
+/// Afrim Wish CLI.
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 struct Args {
@@ -21,37 +19,22 @@ struct Args {
 fn main() {
     let args = Args::parse();
 
-    let wish_conf = WishConfig::from_file(&args.config_file).unwrap_or_else(|err| {
-        eprintln!("Problem parsing config file: {err}");
-        process::exit(1);
-    });
+    let wish_conf = WishConfig::from_file(&args.config_file).map_err(|err| {
+        Wish::raise_error("Problem parsing config file", &err);
+    }).unwrap();
 
-    let mut frontend = Wish::init(wish_conf);
-    frontend.build();
+    let wish = Wish::from_config(wish_conf);
 
-    // We start the backend
-    {
-        let frontend = frontend.clone();
+    let clafrica_conf = ClafricaConfig::from_file(&args.config_file).map_err(|err| {
+        Wish::raise_error("Problem parsing config file", &err);
+    }).unwrap();
 
-        thread::spawn(move || {
-            let clafrica_conf =
-                ClafricaConfig::from_file(&args.config_file).unwrap_or_else(|err| {
-                    frontend.raise_error("Problem parsing config file", &err.to_string());
-                    process::exit(1);
-                });
-
-            // End the program if check only.
-            if args.check {
-                frontend.destroy();
-            }
-
-            if let Err(e) = run(clafrica_conf, frontend.clone()) {
-                frontend.raise_error("Application error", &e.to_string());
-                process::exit(1);
-            }
-        });
+    // End the program if check only.
+    if args.check {
+        Wish::kill();
     }
 
-    // We start listening gui events
-    frontend.listen();
+    if let Err(err) = run(clafrica_conf, wish) {
+        Wish::raise_error("Application error", &err);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,15 +19,19 @@ struct Args {
 fn main() {
     let args = Args::parse();
 
-    let wish_conf = WishConfig::from_file(&args.config_file).map_err(|err| {
-        Wish::raise_error("Problem parsing config file", &err);
-    }).unwrap();
+    let wish_conf = WishConfig::from_file(&args.config_file)
+        .map_err(|err| {
+            Wish::raise_error("Problem parsing config file", &err);
+        })
+        .unwrap();
 
     let wish = Wish::from_config(wish_conf);
 
-    let clafrica_conf = ClafricaConfig::from_file(&args.config_file).map_err(|err| {
-        Wish::raise_error("Problem parsing config file", &err);
-    }).unwrap();
+    let clafrica_conf = ClafricaConfig::from_file(&args.config_file)
+        .map_err(|err| {
+            Wish::raise_error("Problem parsing config file", &err);
+        })
+        .unwrap();
 
     // End the program if check only.
     if args.check {


### PR DESCRIPTION
### Related issue
- #40 
- indirectly linked to #60 

### Change
This update will permit to implement more features.
By example, pausing/resuming the afrim.

As major additional change:
- we rename `Wish::destroy` by `Wish::kill`,
 since it closes the program (both wish and rust) internally
- we change the default behavior of the close button of the titlebar
 on the main window